### PR TITLE
Fixed issue with deserialization of the response objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,5 +10,5 @@ Encoding: UTF-8
 License: Unlicense
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, caTools
+Imports: jsonlite, httr, R6, caTools, rlang
 RoxygenNote: 6.0.1.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,5 +10,5 @@ Encoding: UTF-8
 License: Unlicense
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, caTools, rlang
+Imports: jsonlite, httr, R6, caTools, rlang (>= 0.4.1)
 RoxygenNote: 6.0.1.9000

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -116,7 +116,10 @@ ApiClient  <- R6::R6Class(
     # Deserialize the content of api response to the given type.
     deserialize = function(resp, returnType, pkgEnv) {
       respObj <- jsonlite::fromJSON(httr::content(resp, "text", encoding = "UTF-8"))
-      self$deserializeObj(respObj, returnType, pkgEnv)
+      respObj$data
+      
+      # This deserialization yields a NULL object
+      #self$deserializeObj(respObj, returnType, pkgEnv)
     },
 
 


### PR DESCRIPTION
This now works with a few of the api calls I've tried but haven't tested everything yet. @avaidyam let me know why you think the deserialization wasn't working in the first place and if its worth fixing that part (or if we can remove).